### PR TITLE
new cover fix for non-steam-games

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -22,7 +22,13 @@ func getBackupPath(gridDir string, game *Game, artStyleExtensions []string) stri
 	hash := sha256.Sum256(game.OverlayImageBytes)
 	// [:] is required to convert a fixed length byte array to a byte slice.
 	hexHash := hex.EncodeToString(hash[:])
-	return filepath.Join(gridDir, "originals", game.ID + artStyleExtensions[0] + " " + hexHash+game.ImageExt)
+	backupFileName := ""
+	if artStyleExtensions[0] == "p"{
+		backupFileName = game.CoverID
+	} else {
+		backupFileName = game.ID
+	}
+	return filepath.Join(gridDir, "originals", backupFileName + artStyleExtensions[0] + " " + hexHash+game.ImageExt)
 }
 
 func RemoveExisting(gridDir string, gameId string, artStyleExtensions []string) error {

--- a/games.go
+++ b/games.go
@@ -14,6 +14,7 @@ import (
 type Game struct {
 	// Official Steam id.
 	ID string
+	CoverID string
 	// Warning, may contain Unicode characters.
 	Name string
 	// Tags, including user-created category and Steam's "Favorite" tag.
@@ -47,7 +48,7 @@ func addGamesFromProfile(user User, games map[string]*Game) (err error) {
 		gameID := groups[1]
 		gameName := groups[2]
 		tags := []string{""}
-		games[gameID] = &Game{gameID, gameName, tags, "", nil, nil, ""}
+		games[gameID] = &Game{gameID, gameID, gameName, tags, "", nil, nil, ""}
 	}
 
 	return
@@ -85,7 +86,7 @@ func addUnknownGames(user User, games map[string]*Game) {
 				// If for some reason it wasn't included in the profile, create a new
 				// entry for it now. Unfortunately we don't have a name.
 				gameName := ""
-				games[gameID] = &Game{gameID, gameName, []string{tag}, "", nil, nil, ""}
+				games[gameID] = &Game{gameID, gameID, gameName, []string{tag}, "", nil, nil, ""}
 			}
 		}
 	}
@@ -118,7 +119,7 @@ func addNonSteamGames(user User, games map[string]*Game) {
 		// to 64bit Steam ID. No idea why Steam chose this operation.
 		top := uint64(crc32.ChecksumIEEE(uniqueName)) | 0x80000000
 		gameID := strconv.FormatUint(top<<32|0x02000000, 10)
-		game := Game{gameID, string(gameName), []string{}, "", nil, nil, ""}
+		game := Game{gameID, strconv.FormatUint(top, 10), string(gameName), []string{}, "", nil, nil, ""}
 		games[gameID] = &game
 
 		tagsText := gameGroups[3]

--- a/steamgrid.go
+++ b/steamgrid.go
@@ -203,7 +203,12 @@ func startApplication() {
 					errorAndExit(err)
 				}
 
-				imagePath := filepath.Join(gridDir, game.ID + artStyleExtensions[0] + game.ImageExt)
+				imagePath := ""
+				if artStyle == "Cover" {
+					imagePath = filepath.Join(gridDir, game.CoverID + artStyleExtensions[0] + game.ImageExt)
+				}  else if artStyle == "Banner" {
+					imagePath = filepath.Join(gridDir, game.ID + artStyleExtensions[0] + game.ImageExt)
+				}
 				err = ioutil.WriteFile(imagePath, game.OverlayImageBytes, 0666)
 				if err != nil {
 					fmt.Printf("Failed to write image for %v (%v) because: %v\n", game.Name, artStyle, err.Error())


### PR DESCRIPTION
> Steam refused to set a custom image for my added games. (nothing happens when I set a custom artwork)
> Do they work for you when set from inside steam? (I guess this is a yes)
> Do you know how the new name is known? The current/old way is here:
> 
> https://github.com/boppreh/steamgrid/blob/eac4d3fef11a1f4bf6f85d1e6fc0ff089c5fcbd1/games.go#L114-L120
> 
> When comparing with my file I spotted some differences in my actual file:
> 
> ```diff
> - (?i)appname\x00(.+?)\x00\x01exe\x00(.+?)\x00\x01.+?\x00tags\x00(.*?)\x08\x08
> + (?i)\x00\x01appname\x00(.+?)\x00\x01exe\x00(.+?)\x00\x01.+?\x00tags\x00\x01(.*?)\x08\x08
> ```

The filename for the new ui covers is what the operation at line 119 generates.

For my example "The Witcher 3 - Wild Hunt":

fmt.Println(top)

> 3127296488

fmt.Println(gameID)

> 13431636140889210880

image-files in ".../config/grid/":

3127296488p.jpg 
13431636140889210880.jpeg

