### PR TITLE
Fixed error check

### DIFF
--- a/download.go
+++ b/download.go
@@ -99,10 +99,10 @@ const SteamGridDBBaseURL = "https://www.steamgriddb.com/api/v2"
 func SteamGridDBGetRequest(url string, steamGridDBApiKey string) ([]byte, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer " + steamGridDBApiKey)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Add("Authorization", "Bearer " + steamGridDBApiKey)
 
 	response, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
err should be checked before using req to avoid nil pointer dereference panic